### PR TITLE
Refactor and integrate recipe image generation using Stable Diffusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+/recipes/
+/generated_images/

--- a/image_generation.py
+++ b/image_generation.py
@@ -1,6 +1,7 @@
 ﻿import base64
 import os
-import requests
+from io import BytesIO
+from huggingface_hub import InferenceClient
 
 
 class RecipeImageGenerator:
@@ -10,32 +11,35 @@ class RecipeImageGenerator:
         self.__stable_diffusion_api_key = os.environ.get("STABLE_DIFFUSION_API_KEY")
 
     def generate_with_stable_diffusion(self, recipe_name: str) -> str | None:
-        api_url = "https://api-inference.huggingface.co/models/stabilityai/stable-diffusion-xl-base-1.0"
-        headers = {"Authorization": f"Bearer {self.__stable_diffusion_api_key}"}
+        client = InferenceClient(
+            provider="nebius",
+            api_key=self.__stable_diffusion_api_key
+        )
 
-        payload = {
-            "inputs": f"A beautiful small image of a {recipe_name}",
-            "options": {"wait_for_model": True}
-        }
+        image = client.text_to_image(
+            f"A beautiful small image of a {recipe_name}",
+            model="stabilityai/stable-diffusion-xl-base-1.0",
+        )
 
-        response = requests.post(api_url, headers=headers, json=payload)
+        # self.save_image_to_disk(image, recipe_name)
 
-        if response.status_code == 200:
-            image_bytes = response.content
+        return self.pil_to_base64(image)
 
-            image_dir = "generated_images"
-            if not os.path.exists(image_dir):
-                os.makedirs(image_dir)
+    @staticmethod
+    def save_image_to_disk(image, recipe_name):
+        image_dir = "generated_images"
+        if not os.path.exists(image_dir):
+            os.makedirs(image_dir)
 
-            safe_filename = "".join(c for c in recipe_name if c.isalnum() or c in (' ', '_')).rstrip().replace(' ', '_')
-            image_path = os.path.join(image_dir, f"{safe_filename}.jpg")
+        safe_filename = "".join(c for c in recipe_name if c.isalnum() or c in (' ', '_')).rstrip().replace(' ', '_')
+        image_path = os.path.join(image_dir, f"{safe_filename}.jpg")
+        image.save(image_path, format='JPEG')
 
-            with open(image_path, "wb") as f:
-                f.write(image_bytes)
+        print(f"Image saved to {image_path}")
 
-            print(f"Image saved to {image_path}")
+    @staticmethod
+    def pil_to_base64(image):
+        buffer = BytesIO()
+        image.save(buffer, format='JPEG')
 
-            return base64.b64encode(image_bytes).decode("utf-8")
-        else:
-            print(f"Error generating image: {response.text}")
-            return None
+        return base64.b64encode(buffer.getvalue()).decode('utf-8')

--- a/image_generation.py
+++ b/image_generation.py
@@ -1,0 +1,41 @@
+﻿import base64
+import os
+import requests
+
+
+class RecipeImageGenerator:
+    __prompt = f"A small image for the following recipe description for a paprika recipe manager (https://www.paprikaapp.com/):"
+
+    def __init__(self):
+        self.__stable_diffusion_api_key = os.environ.get("STABLE_DIFFUSION_API_KEY")
+
+    def generate_with_stable_diffusion(self, recipe_name: str) -> str | None:
+        api_url = "https://api-inference.huggingface.co/models/stabilityai/stable-diffusion-xl-base-1.0"
+        headers = {"Authorization": f"Bearer {self.__stable_diffusion_api_key}"}
+
+        payload = {
+            "inputs": f"A beautiful small image of a {recipe_name}",
+            "options": {"wait_for_model": True}
+        }
+
+        response = requests.post(api_url, headers=headers, json=payload)
+
+        if response.status_code == 200:
+            image_bytes = response.content
+
+            image_dir = "generated_images"
+            if not os.path.exists(image_dir):
+                os.makedirs(image_dir)
+
+            safe_filename = "".join(c for c in recipe_name if c.isalnum() or c in (' ', '_')).rstrip().replace(' ', '_')
+            image_path = os.path.join(image_dir, f"{safe_filename}.jpg")
+
+            with open(image_path, "wb") as f:
+                f.write(image_bytes)
+
+            print(f"Image saved to {image_path}")
+
+            return base64.b64encode(image_bytes).decode("utf-8")
+        else:
+            print(f"Error generating image: {response.text}")
+            return None

--- a/paprika.py
+++ b/paprika.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from typing import List, Optional
 from lufa import LufaRecipe
+from image_generation import RecipeImageGenerator
 
 
 @dataclass
@@ -38,6 +39,8 @@ class PaprikaRecipe:
 
     @classmethod
     def from_lufa_recipe(cls, lufa_recipe: LufaRecipe) -> 'PaprikaRecipe':
+        generator = RecipeImageGenerator()
+
         return cls(
             name=lufa_recipe.name,
             ingredients=lufa_recipe.ingredients,
@@ -49,6 +52,7 @@ class PaprikaRecipe:
             source=lufa_recipe.source,
             source_url=lufa_recipe.source,
             categories=lufa_recipe.categories,
+            photo_data=generator.generate_with_stable_diffusion(lufa_recipe.name)
         )
 
     def to_dict(self) -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+﻿PyMuPDF~=1.26.3
+requests~=2.32.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ﻿PyMuPDF~=1.26.3
-requests~=2.32.4
+huggingface-hub~=0.33.4


### PR DESCRIPTION
```
### Description

This pull request refactors the image generation process by leveraging the `InferenceClient` from Hugging Face. The `.gitignore` is updated to exclude `/recipes` and `/generated_images` directories for better project organization. Additionally, it integrates the `RecipeImageGenerator` class into the `from_lufa_recipe` method, introducing recipe image generation via the Stable Diffusion API.

### Changes

- Refactor image generation to use Hugging Face's `InferenceClient`.
- Remove the `requests` dependency and update `requirements.txt`.
- Update `.gitignore` for `/recipes` and `/generated_images`.
- Integrate `RecipeImageGenerator` to automate image creation.
- Add recipe image generation using the Stable Diffusion API.
```